### PR TITLE
Add sending motion data

### DIFF
--- a/vita/CMakeLists.txt
+++ b/vita/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(${VITA_APP_NAME}.elf
   SceAppUtil_stub
   SceRegistryMgr_stub
 
+  SceMotion_stub
   SceTouch_stub
 #   SceHttp_stub
   SceNet_stub


### PR DESCRIPTION
This adds sending motion data. I tested with Genshin Impact on the PS5 and everything was working perfectly, it might be worth putting this behind a toggle setting if it has any impact on performance? Though I didn't notice any particular difference.