### PR TITLE
Read sticks compatibly with AnalogsEnhancer

### DIFF
--- a/vita/src/host.c
+++ b/vita/src/host.c
@@ -205,7 +205,7 @@ static void *input_thread_func(void* user) {
       int start_time_us = sceKernelGetProcessTimeWide();
 
       // get button state
-      sceCtrlPeekBufferPositiveExt2(0, &ctrl, 1);
+      sceCtrlPeekBufferPositive(0, &ctrl, 1);
 
       // get touchscreen state
       for(int port = 0; port < SCE_TOUCH_PORT_MAX_NUM; port++) {
@@ -295,14 +295,14 @@ static void *input_thread_func(void* user) {
       if (ctrl.buttons & SCE_CTRL_L3)       stream->controller_state.buttons |= CHIAKI_CONTROLLER_BUTTON_L3;
       if (ctrl.buttons & SCE_CTRL_R3)       stream->controller_state.buttons |= CHIAKI_CONTROLLER_BUTTON_R3;
 
-      if (ctrl.buttons & SCE_CTRL_L1) {
+      if (ctrl.buttons & SCE_CTRL_LTRIGGER) {
         if (reartouch_left && vitaki_reartouch_left_l1_mapped) {
           set_ctrl_l2pos(stream, VITAKI_CTRL_IN_REARTOUCH_LEFT_L1);
         } else {
           set_ctrl_l2pos(stream, VITAKI_CTRL_IN_L1);
         }
       }
-      if (ctrl.buttons & SCE_CTRL_R1) {
+      if (ctrl.buttons & SCE_CTRL_RTRIGGER) {
         if (reartouch_right && vitaki_reartouch_right_r1_mapped) {
           set_ctrl_r2pos(stream, VITAKI_CTRL_IN_REARTOUCH_RIGHT_R1);
         } else {


### PR DESCRIPTION
This just changes the function it uses to retrieve the button/stick data because reading from the "2" version of the function was making it ignore the deadzone calibration from AnalogsEnhancer. Seeing as L2/R2 from the wireless controller doesn't seem to be used anyways I don't think this has any regressions for normal use.