### PR TITLE
Swap circle/cross in main UI on Japanese vitas (fixes #23)

### DIFF
--- a/vita/include/config.h
+++ b/vita/include/config.h
@@ -32,6 +32,7 @@ typedef struct vita_chiaki_config_t {
   // TODO: Loglevel
   // controller map id // TODO should probably replace with fully customizable map
   int controller_map_id;
+  bool circle_btn_select;
 } VitaChiakiConfig;
 
 void config_parse(VitaChiakiConfig* cfg);

--- a/vita/include/config.h
+++ b/vita/include/config.h
@@ -32,7 +32,7 @@ typedef struct vita_chiaki_config_t {
   // TODO: Loglevel
   // controller map id // TODO should probably replace with fully customizable map
   int controller_map_id;
-  bool circle_btn_select;
+  bool circle_btn_confirm;
 } VitaChiakiConfig;
 
 void config_parse(VitaChiakiConfig* cfg);

--- a/vita/src/config.c
+++ b/vita/src/config.c
@@ -55,6 +55,22 @@ ChiakiTarget parse_target(char* target_name) {
   return CHIAKI_TARGET_PS4_UNKNOWN;
 }
 
+bool get_circle_btn_select_default() {
+  // Check system settings to see if circle should be select instead of cross
+  // (should be true on Japanese vitas and false elsewhere).
+
+	int button_assign = -1;
+	int ret = 0;
+	ret = sceRegMgrGetKeyInt("/CONFIG/SYSTEM", "button_assign", &button_assign);
+  if (ret < 0) {
+    // Failed to determine. Just return false.
+    return false;
+  }
+
+  // 0 => circle select; 1 => cross select; other values invalid (so default to false)
+  return (button_assign == 0);
+}
+
 void config_parse(VitaChiakiConfig* cfg) {
   cfg->psn_account_id = NULL;
   cfg->auto_discovery = true;
@@ -62,6 +78,10 @@ void config_parse(VitaChiakiConfig* cfg) {
   cfg->resolution = CHIAKI_VIDEO_RESOLUTION_PRESET_540p;
   cfg->fps = CHIAKI_VIDEO_FPS_PRESET_30;
   cfg->controller_map_id = 0;
+
+  bool circle_btn_select_default = get_circle_btn_select_default();
+  cfg->circle_btn_select = circle_btn_select_default;
+
   if (access(CFG_FILENAME, F_OK) == 0) {
     FILE* fp = fopen(CFG_FILENAME, "r");
     char errbuf[200];
@@ -118,6 +138,9 @@ void config_parse(VitaChiakiConfig* cfg) {
       if (datum.ok) {
         cfg->controller_map_id = datum.u.i;
       }
+
+      datum = toml_bool_in(settings, "circle_btn_select");
+      cfg->circle_btn_select = datum.ok ? datum.u.b : circle_btn_select_default;
     }
 
     toml_array_t* regist_hosts = toml_array_in(parsed, "registered_hosts");
@@ -356,6 +379,8 @@ void config_serialize(VitaChiakiConfig* cfg) {
     fprintf(fp, "psn_account_id = \"%s\"\n", cfg->psn_account_id);
   }
   fprintf(fp, "controller_map_id = %d\n", cfg->controller_map_id);
+  fprintf(fp, "circle_btn_select = %s\n",
+          cfg->circle_btn_select ? "true" : "false");
 
   for (int i = 0; i < cfg->num_manual_hosts; i++) {
     VitaChiakiHost* host = cfg->manual_hosts[i];

--- a/vita/src/config.c
+++ b/vita/src/config.c
@@ -55,7 +55,7 @@ ChiakiTarget parse_target(char* target_name) {
   return CHIAKI_TARGET_PS4_UNKNOWN;
 }
 
-bool get_circle_btn_select_default() {
+bool get_circle_btn_confirm_default() {
   // Check system settings to see if circle should be select instead of cross
   // (should be true on Japanese vitas and false elsewhere).
 
@@ -79,8 +79,8 @@ void config_parse(VitaChiakiConfig* cfg) {
   cfg->fps = CHIAKI_VIDEO_FPS_PRESET_30;
   cfg->controller_map_id = 0;
 
-  bool circle_btn_select_default = get_circle_btn_select_default();
-  cfg->circle_btn_select = circle_btn_select_default;
+  bool circle_btn_confirm_default = get_circle_btn_confirm_default();
+  cfg->circle_btn_confirm = circle_btn_confirm_default;
 
   if (access(CFG_FILENAME, F_OK) == 0) {
     FILE* fp = fopen(CFG_FILENAME, "r");
@@ -139,8 +139,8 @@ void config_parse(VitaChiakiConfig* cfg) {
         cfg->controller_map_id = datum.u.i;
       }
 
-      datum = toml_bool_in(settings, "circle_btn_select");
-      cfg->circle_btn_select = datum.ok ? datum.u.b : circle_btn_select_default;
+      datum = toml_bool_in(settings, "circle_btn_confirm");
+      cfg->circle_btn_confirm = datum.ok ? datum.u.b : circle_btn_confirm_default;
     }
 
     toml_array_t* regist_hosts = toml_array_in(parsed, "registered_hosts");
@@ -379,8 +379,8 @@ void config_serialize(VitaChiakiConfig* cfg) {
     fprintf(fp, "psn_account_id = \"%s\"\n", cfg->psn_account_id);
   }
   fprintf(fp, "controller_map_id = %d\n", cfg->controller_map_id);
-  fprintf(fp, "circle_btn_select = %s\n",
-          cfg->circle_btn_select ? "true" : "false");
+  fprintf(fp, "circle_btn_confirm = %s\n",
+          cfg->circle_btn_confirm ? "true" : "false");
 
   for (int i = 0; i < cfg->num_manual_hosts; i++) {
     VitaChiakiHost* host = cfg->manual_hosts[i];

--- a/vita/src/ui.c
+++ b/vita/src/ui.c
@@ -91,10 +91,10 @@ typedef enum ui_screen_type_t {
 } UIScreenType;
 
 // Initialize Yes and No button from settings (will be updated in init_ui)
-int SCE_CTRL_YES = SCE_CTRL_CROSS;
-int SCE_CTRL_NO  = SCE_CTRL_CIRCLE;
-char* yes_btn_str = "Cross";
-char* no_btn_str  = "Circle";
+int SCE_CTRL_CONFIRM = SCE_CTRL_CROSS;
+int SCE_CTRL_CANCEL  = SCE_CTRL_CIRCLE;
+char* confirm_btn_str = "Cross";
+char* cancel_btn_str  = "Circle";
 
 /// Check if a button has been newly pressed
 bool btn_pressed(SceCtrlButtons btn) {
@@ -220,17 +220,17 @@ UIHostAction host_tile(int host_slot, VitaChiakiHost* host) {
   if (is_active) {
     if (at_rest) {
       if (registered) {
-        snprintf(active_tile_tooltip_msg, MAX_TOOLTIP_CHARS, "%s: send wake signal (note: console may be temporarily undetected during wakeup)", yes_btn_str);
+        snprintf(active_tile_tooltip_msg, MAX_TOOLTIP_CHARS, "%s: send wake signal (note: console may be temporarily undetected during wakeup)", confirm_btn_str);
       } else {
         snprintf(active_tile_tooltip_msg, MAX_TOOLTIP_CHARS, "Cannot send wake signal to unregistered console.");
       }
     } else {
       if (discovered && !registered) {
-        snprintf(active_tile_tooltip_msg, MAX_TOOLTIP_CHARS, "%s: begin pairing process", yes_btn_str);
+        snprintf(active_tile_tooltip_msg, MAX_TOOLTIP_CHARS, "%s: begin pairing process", confirm_btn_str);
       } else if (discovered && registered) {
-        snprintf(active_tile_tooltip_msg, MAX_TOOLTIP_CHARS, "%s: start remote play;  Square: re-pair", yes_btn_str);
+        snprintf(active_tile_tooltip_msg, MAX_TOOLTIP_CHARS, "%s: start remote play;  Square: re-pair", confirm_btn_str);
       } else if (added) {
-        snprintf(active_tile_tooltip_msg, MAX_TOOLTIP_CHARS, "%s: send wake signal and/or start remote play (wakeup takes time);  SELECT button: delete host (no confirmation)", yes_btn_str);
+        snprintf(active_tile_tooltip_msg, MAX_TOOLTIP_CHARS, "%s: send wake signal and/or start remote play (wakeup takes time);  SELECT button: delete host (no confirmation)", confirm_btn_str);
       } else {
         // there should never be tiles that are neither discovered nor added
         snprintf(active_tile_tooltip_msg, MAX_TOOLTIP_CHARS, "");
@@ -282,7 +282,7 @@ UIHostAction host_tile(int host_slot, VitaChiakiHost* host) {
       update_context_hosts();
     }
     // Determine action to perform
-    // if (btn_pressed(SCE_CTRL_YES) && !registered) {
+    // if (btn_pressed(SCE_CTRL_CONFIRM) && !registered) {
     //   for (int i = 0; i < context.config.num_registered_hosts; i++) {
     //     printf("0x%x", context.config.registered_hosts[i]->registered_state);
     //     if (context.config.registered_hosts[i] != NULL && strcmp(context.active_host->hostname, context.config.registered_hosts[i]->hostname) == 0) {
@@ -293,7 +293,7 @@ UIHostAction host_tile(int host_slot, VitaChiakiHost* host) {
     //     }
     //   }
     // }
-    // if (btn_pressed(SCE_CTRL_YES) && !registered && !added) {
+    // if (btn_pressed(SCE_CTRL_CONFIRM) && !registered && !added) {
     //   for (int i = 0; i < context.config.num_manual_hosts; i++) {
     //     if (context.config.manual_hosts[i] != NULL && strcmp(context.active_host->hostname, context.config.manual_hosts[i]->hostname) == 0) {
     //       context.active_host->registered_state = context.config.manual_hosts[i]->registered_state;
@@ -304,7 +304,7 @@ UIHostAction host_tile(int host_slot, VitaChiakiHost* host) {
     //     }
     //   }
     // }
-    if (registered && btn_pressed(SCE_CTRL_YES)) {
+    if (registered && btn_pressed(SCE_CTRL_CONFIRM)) {
       if (at_rest) {
         return UI_HOST_ACTION_WAKEUP;
       } else {
@@ -316,7 +316,7 @@ UIHostAction host_tile(int host_slot, VitaChiakiHost* host) {
         int err = host_stream(context.active_host);
         return UI_HOST_ACTION_STREAM;
       }
-    } else if (!registered && !added && discovered && btn_pressed(SCE_CTRL_YES)){
+    } else if (!registered && !added && discovered && btn_pressed(SCE_CTRL_CONFIRM)){
       if (at_rest) {
         LOGD("Cannot wake unregistered console.");
         return UI_HOST_ACTION_NONE;
@@ -374,7 +374,7 @@ bool header_button(MainWidgetId id, int x_offset, vita2d_texture* default_img,
     context.ui_state.next_active_item = id;
     return true;
   }
-  return is_active && btn_pressed(SCE_CTRL_YES);
+  return is_active && btn_pressed(SCE_CTRL_CONFIRM);
 }
 uint16_t IMEInput[SCE_IME_DIALOG_MAX_TEXT_LENGTH + 1];
 bool showingIME = false;
@@ -383,7 +383,7 @@ char* text_input(MainWidgetId id, int x, int y, int w, int h, char* label,
   bool is_active = context.ui_state.active_item == id;
   if (is_active) {
     vita2d_draw_rectangle(x + 300 - 3, y - 3, w + 6, h + 6, COLOR_ACTIVE);
-    if (btn_pressed(SCE_CTRL_YES)) {
+    if (btn_pressed(SCE_CTRL_CONFIRM)) {
       SceImeDialogParam param;
 
       sceImeDialogParamInit(&param);
@@ -450,7 +450,7 @@ long int number_input(MainWidgetId id, int x, int y, int w, int h, char* label, 
   bool is_active = context.ui_state.active_item == id;
   if (is_active) {
     vita2d_draw_rectangle(x + 300 - 3, y - 3, w + 6, h + 6, COLOR_ACTIVE);
-    if (btn_pressed(SCE_CTRL_YES)) {
+    if (btn_pressed(SCE_CTRL_CONFIRM)) {
       SceImeDialogParam param;
 
       sceImeDialogParamInit(&param);
@@ -737,7 +737,7 @@ bool draw_settings() {
     config_serialize(&context.config);
   }
 
-  if (btn_pressed(SCE_CTRL_NO)) {
+  if (btn_pressed(SCE_CTRL_CANCEL)) {
     context.ui_state.next_active_item = UI_MAIN_WIDGET_SETTINGS_BTN;
     // free(context.config.psn_account_id);
     // context.config.psn_account_id = NULL;
@@ -757,7 +757,7 @@ bool draw_registration_dialog() {
   int tooltip_x = 10;
   int tooltip_y = VITA_HEIGHT - font_size;
   vita2d_font_draw_textf(font, tooltip_x, tooltip_y, COLOR_WHITE, font_size,
-                         "Triangle: Register (clear any current registration);  %s: Exit without registering.", no_btn_str
+                         "Triangle: Register (clear any current registration);  %s: Exit without registering.", cancel_btn_str
                         );
 
   // Draw isntructions
@@ -785,7 +785,7 @@ bool draw_registration_dialog() {
       LOGD("User exited registration screen without inputting link code");
     }
   }
-  if (btn_pressed(SCE_CTRL_NO) || btn_pressed(SCE_CTRL_TRIANGLE)) {
+  if (btn_pressed(SCE_CTRL_CANCEL) || btn_pressed(SCE_CTRL_TRIANGLE)) {
     LINK_CODE = -1;
     context.ui_state.next_active_item = UI_MAIN_WIDGET_SETTINGS_BTN;
     return false;
@@ -825,7 +825,7 @@ bool draw_add_host_dialog() {
                           "Pair to a console on a local network first."
                           );
 
-    if (btn_pressed(SCE_CTRL_NO) | btn_pressed(SCE_CTRL_YES)) {
+    if (btn_pressed(SCE_CTRL_CANCEL) | btn_pressed(SCE_CTRL_CONFIRM)) {
       context.ui_state.next_active_item = UI_MAIN_WIDGET_ADD_HOST_BTN;
       REMOTEIP = "";
       CONSOLENUM = -1;
@@ -909,7 +909,7 @@ bool draw_add_host_dialog() {
   int tooltip_x = 10;
   int tooltip_y = VITA_HEIGHT - font_size;
   vita2d_font_draw_textf(font, tooltip_x, tooltip_y, COLOR_WHITE, font_size,
-                         "Triangle: save and add host;  %s: Exit without saving.", no_btn_str
+                         "Triangle: save and add host;  %s: Exit without saving.", cancel_btn_str
                         );
 
   if (btn_pressed(SCE_CTRL_DOWN)) {
@@ -931,7 +931,7 @@ bool draw_add_host_dialog() {
   }
 
   // cancel
-  if (btn_pressed(SCE_CTRL_NO)) {
+  if (btn_pressed(SCE_CTRL_CANCEL)) {
     context.ui_state.next_active_item = UI_MAIN_WIDGET_ADD_HOST_BTN;
     REMOTEIP = "";
     CONSOLENUM = -1;
@@ -1087,7 +1087,7 @@ bool draw_messages() {
     }
   }
 
-  if (btn_pressed(SCE_CTRL_NO)) {
+  if (btn_pressed(SCE_CTRL_CANCEL)) {
     // TODO abort connection if connecting
     vita2d_set_clear_color(RGBA8(0x40, 0x40, 0x40, 0xFF));
     context.ui_state.next_active_item = UI_MAIN_WIDGET_MESSAGES_BTN;
@@ -1105,10 +1105,10 @@ void init_ui() {
   vita2d_set_vblank_wait(true);
 
   // Set yes/no buttons (circle = yes on Japanese vitas, typically)
-  SCE_CTRL_YES = context.config.circle_btn_select ? SCE_CTRL_CIRCLE : SCE_CTRL_CROSS;
-  SCE_CTRL_NO  = context.config.circle_btn_select ? SCE_CTRL_CROSS : SCE_CTRL_CIRCLE;
-  yes_btn_str = context.config.circle_btn_select ? "Circle" : "Cross";
-  no_btn_str  = context.config.circle_btn_select ? "Cross" : "Circle";
+  SCE_CTRL_CONFIRM = context.config.circle_btn_confirm ? SCE_CTRL_CIRCLE : SCE_CTRL_CROSS;
+  SCE_CTRL_CANCEL  = context.config.circle_btn_confirm ? SCE_CTRL_CROSS : SCE_CTRL_CIRCLE;
+  confirm_btn_str = context.config.circle_btn_confirm ? "Circle" : "Cross";
+  cancel_btn_str  = context.config.circle_btn_confirm ? "Cross" : "Circle";
 }
 
 /// Main UI loop


### PR DESCRIPTION
1. Automatically detect the correct setting.
2. Add a config option to `chiaki.toml` in case the user wants to change it manually or the automatic detection fails:

```toml
circle_btn_confirm = true
```
(or `false`)