### PR TITLE
Implement `priority_hosts` option in config for crowded network (fixes #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,22 @@ Note: if the remote host cannot be reached, it will get stuck on "Trying to requ
 
 ## Config settings
 Some configuration lacks a UI but can be set in the config file located at `ux0:data/vita-chiaki/chiaki.toml`.
-- `circle_btn_confirm = true` swaps circle and cross in the main UI, so that circle is confirm and cross is cancel (`false` makes cross into confirm and circle into cancel). Note that this does not affect the button mappings in remote play, only in the UI before remote play starts.
-- `auto_discovery = false` makes Vitaki not start discovery on launch. It can still be started manually by selecting the wifi icon.
+### Swapping circle/cross in UI
+`circle_btn_confirm = true` swaps circle and cross in the main UI, so that circle is confirm and cross is cancel (`false` makes cross into confirm and circle into cancel). Note that this does not affect the button mappings in remote play, only in the UI before remote play starts.
+### Disabling auto discovery
+`auto_discovery = false` makes Vitaki not start discovery on launch. It can still be started manually by selecting the wifi icon.
+### Priority hosts
+The Vitaki UI is limited to 4 consoles. If you are on a crowded network with many consoles and yours isn't showing up, you can manually add the following to the config file:
+```toml
+[[priority_hosts]]
+server_mac = "00:11:11:11:11:11"
+
+[[priority_hosts]]
+server_mac = "00:22:22:22:22:22"
+```
+and so on for each console you want to prioritize, where the MAC address is the LAN MAC address of your PS5/PS4 console (you can find it in `Settings > Network > Connection Status > View Connection Status`).
+
+Note that each additional priority host should have its own `[[priority_hosts]]` header above it. Also, be sure to quote the MAC address. If Vitaki crashes immediately on opening, it is probably due to an invalid TOML file breaking the parser.
 
 ## Known issues & troubleshooting
 - [Latency](https://github.com/ywnico/vitaki-fork/issues/12). On remote connections (not local WLAN), it's especially bad.

--- a/vita/include/config.h
+++ b/vita/include/config.h
@@ -28,6 +28,10 @@ typedef struct vita_chiaki_config_t {
   VitaChiakiHost* manual_hosts[MAX_NUM_HOSTS];
   size_t num_registered_hosts;
   VitaChiakiHost* registered_hosts[MAX_NUM_HOSTS];
+
+  size_t num_priority_host_macs;
+  uint8_t* priority_host_macs[MAX_NUM_HOSTS];
+
   // TODO: Logfile path
   // TODO: Loglevel
   // controller map id // TODO should probably replace with fully customizable map

--- a/vita/include/host.h
+++ b/vita/include/host.h
@@ -17,6 +17,7 @@ typedef struct vita_chiaki_host_t {
   ChiakiTarget target;
   uint8_t server_mac[6];
   char* hostname;
+  bool is_priority;
 
   ChiakiDiscoveryHost* discovery_state;
   ChiakiRegisteredHost* registered_state;

--- a/vita/include/util.h
+++ b/vita/include/util.h
@@ -3,9 +3,11 @@
 #include <inttypes.h>
 #include <sys/types.h>
 
-void parse_b64(const char* val, uint8_t* dest, size_t len);
+int parse_b64(const char* val, uint8_t* dest, size_t len);
 
-void parse_mac(const char* mac_str, uint8_t* mac_dest);
+int parse_mac_hex_or_b64(const char* mac_str, uint8_t* mac_dest);
+
+int parse_mac(const char* mac_str, uint8_t* mac_dest);
 
 void utf16_to_utf8(const uint16_t *src, uint8_t *dst);
 

--- a/vita/include/util.h
+++ b/vita/include/util.h
@@ -9,6 +9,8 @@ int parse_mac_hex_or_b64(const char* mac_str, uint8_t* mac_dest);
 
 int parse_mac(const char* mac_str, uint8_t* mac_dest);
 
+bool mac_is_priority(uint8_t* host_mac);
+
 void utf16_to_utf8(const uint16_t *src, uint8_t *dst);
 
 void utf8_to_utf16(const uint8_t *src, uint16_t *dst);

--- a/vita/src/config.c
+++ b/vita/src/config.c
@@ -221,7 +221,7 @@ void config_parse(VitaChiakiConfig* cfg) {
     toml_array_t* manual_hosts = toml_array_in(parsed, "manual_hosts");
     if (manual_hosts && toml_array_kind(manual_hosts) == 't') {
       int num_mhosts = toml_array_nelem(manual_hosts);
-      LOGD("Found %d manual hosts", num_mhosts);
+      LOGD("Config file contains %d manual hosts", num_mhosts);
       for (int i=0; i < MIN(MAX_NUM_HOSTS, num_mhosts) ; i++) {
         VitaChiakiHost* host = NULL;
 
@@ -276,6 +276,38 @@ void config_parse(VitaChiakiConfig* cfg) {
         }
       }
     }
+
+    toml_array_t *priority_hosts = toml_array_in(parsed, "priority_hosts");
+    if (priority_hosts && toml_array_kind(priority_hosts) == 't') {
+      int num_phosts = toml_array_nelem(priority_hosts);
+      LOGD("Config file contains %d priority hosts", num_phosts);
+      for (int i = 0; i < MIN(MAX_NUM_HOSTS, num_phosts); i++) {
+        VitaChiakiHost *host = NULL;
+
+        bool has_mac = false;
+
+        toml_table_t *host_cfg = toml_table_at(priority_hosts, i);
+        datum = toml_string_in(host_cfg, "server_mac");
+        uint8_t server_mac[6];
+        if (datum.ok) {
+          // We have a MAC for the priority host
+          int parse_mac_err = parse_mac_hex_or_b64(datum.u.s, server_mac);
+          has_mac = (parse_mac_err == 0);
+          if (has_mac) {
+            LOGD("Priority MAC parse success: %s -> %X%X%X%X%X%X", datum.u.s,
+                 server_mac[0], server_mac[1], server_mac[2], server_mac[3],
+                 server_mac[4], server_mac[5]);
+            // TODO Save mac to a priority host array
+          } else {
+            LOGD("Priority MAC parse failure: %s", datum.u.s);
+          }
+          free(datum.u.s);
+        }
+      }
+    }
+
+
+
   }
 }
 

--- a/vita/src/config.c
+++ b/vita/src/config.c
@@ -278,6 +278,7 @@ void config_parse(VitaChiakiConfig* cfg) {
     }
 
     toml_array_t *priority_hosts = toml_array_in(parsed, "priority_hosts");
+    cfg->num_priority_host_macs = 0;
     if (priority_hosts && toml_array_kind(priority_hosts) == 't') {
       int num_phosts = toml_array_nelem(priority_hosts);
       LOGD("Config file contains %d priority hosts", num_phosts);
@@ -288,7 +289,7 @@ void config_parse(VitaChiakiConfig* cfg) {
 
         toml_table_t *host_cfg = toml_table_at(priority_hosts, i);
         datum = toml_string_in(host_cfg, "server_mac");
-        uint8_t server_mac[6];
+        uint8_t *server_mac = (uint8_t *)malloc(6 * sizeof(uint8_t));
         if (datum.ok) {
           // We have a MAC for the priority host
           int parse_mac_err = parse_mac_hex_or_b64(datum.u.s, server_mac);
@@ -298,6 +299,8 @@ void config_parse(VitaChiakiConfig* cfg) {
                  server_mac[0], server_mac[1], server_mac[2], server_mac[3],
                  server_mac[4], server_mac[5]);
             // TODO Save mac to a priority host array
+          cfg->num_priority_host_macs++;
+          cfg->priority_host_macs[i] = server_mac;
           } else {
             LOGD("Priority MAC parse failure: %s", datum.u.s);
           }
@@ -322,6 +325,9 @@ void config_free(VitaChiakiConfig* cfg) {
     }
     if (cfg->registered_hosts[i] != NULL) {
       host_free(cfg->registered_hosts[i]);
+    }
+    if (cfg->priority_host_macs[i] != NULL) {
+      free(cfg->priority_host_macs[i]);
     }
   }
   free(cfg);

--- a/vita/src/context.c
+++ b/vita/src/context.c
@@ -40,14 +40,14 @@ void log_cb_debugnet(ChiakiLogLevel lvl, const char *msg, void *user) {
 }
 
 bool vita_chiaki_init_context() {
-  config_parse(&context.config);
-
   // TODO: Load log level from config
   // TODO: Custom logging callback that logs to a file
   chiaki_log_init(&(context.log), CHIAKI_LOG_ALL & ~(CHIAKI_LOG_VERBOSE | CHIAKI_LOG_DEBUG), &log_cb_debugnet, NULL);
   context.mlog = message_log_create();
 
   write_message_log(context.mlog, "----- Debug log start -----"); // debug
+
+  config_parse(&context.config);
 
   // add manual hosts to context
   update_context_hosts();

--- a/vita/src/discovery.c
+++ b/vita/src/discovery.c
@@ -62,22 +62,6 @@ int save_discovered_host(ChiakiDiscoveryHost* host) {
     }
   }
 
-  // Maximum number of hosts reached
-  if (target_idx < 0) {
-    if (is_priority && (non_priority_idx >= 0)) {
-      // The newly discovered host is a priority one and an existing host is
-      // non-priority, so replace the latter.
-      target_idx = non_priority_idx;
-      host_free(context.hosts[target_idx]);
-      context.hosts[target_idx] = NULL;
-      context.num_hosts--;
-    } else {
-      // TODO: Indicate to user that host could not be saved
-      CHIAKI_LOGE(&(context.log), "Max # of hosts reached; could not save newly discovered host.");
-      return -1;
-    }
-  }
-
   // print some info about the host
 
   CHIAKI_LOGI(&(context.log), "--");
@@ -102,20 +86,39 @@ int save_discovered_host(ChiakiDiscoveryHost* host) {
   if(host->host_id)
     CHIAKI_LOGI(&(context.log), "Host ID:                           %s", host->host_id);
 
+  if(host_mac)
+    CHIAKI_LOGI(&(context.log), "Host MAC:                          %X%X%X%X%X%X", host_mac[0], host_mac[1], host_mac[2], host_mac[3], host_mac[4], host_mac[5]);
+
   if(host->running_app_titleid)
     CHIAKI_LOGI(&(context.log), "Running App Title ID:              %s", host->running_app_titleid);
 
   if(host->running_app_name)
     CHIAKI_LOGI(&(context.log), "Running App Name:                  %s%s", host->running_app_name, (strcmp(host->running_app_name, "Persona 5") == 0 ? " (best game ever)" : ""));
 
+  ChiakiTarget target = chiaki_discovery_host_system_version_target(host);
+  CHIAKI_LOGI(&(context.log),   "Is PS5:                            %s", chiaki_target_is_ps5(target) ? "true" : "false");
+  CHIAKI_LOGI(&(context.log),   "Is priority:                       %s", is_priority ? "true" : "false");
+
+  // Maximum number of hosts reached
+  if (target_idx < 0) {
+    if (is_priority && (non_priority_idx >= 0)) {
+      // The newly discovered host is a priority one and an existing host is
+      // non-priority, so replace the latter.
+      target_idx = non_priority_idx;
+      host_free(context.hosts[target_idx]);
+      context.hosts[target_idx] = NULL;
+      context.num_hosts--;
+    } else {
+      // TODO: Indicate to user that host could not be saved
+      CHIAKI_LOGE(&(context.log), "Max # of hosts reached; could not save newly discovered host.");
+      return -1;
+    }
+  }
+
 
   VitaChiakiHost* h = (VitaChiakiHost*)malloc(sizeof(VitaChiakiHost));
   h->registered_state = NULL;
   h->type = DISCOVERED;
-
-  ChiakiTarget target = chiaki_discovery_host_system_version_target(host);
-  CHIAKI_LOGI(&(context.log),   "Is PS5:                            %s", chiaki_target_is_ps5(target) ? "true" : "false");
-  CHIAKI_LOGI(&(context.log),   "Is priority:                       %s", is_priority ? "true" : "false");
   h->target = target;
   memcpy(&(h->server_mac), &host_mac, 6);
   h->discovery_state =

--- a/vita/src/discovery.c
+++ b/vita/src/discovery.c
@@ -225,7 +225,7 @@ ChiakiErrorCode start_discovery(VitaChiakiDiscoveryCb cb, void* cb_user) {
   opts.cb_user = context.discovery_cb_state;
   opts.ping_ms = 500;
   opts.ping_initial_ms = opts.ping_ms;
-  opts.hosts_max = MAX_NUM_HOSTS;
+  opts.hosts_max = 32;
   opts.host_drop_pings = HOST_DROP_PINGS;
 
   sockaddr_in addr = {};

--- a/vita/src/discovery.c
+++ b/vita/src/discovery.c
@@ -70,6 +70,7 @@ int save_discovered_host(ChiakiDiscoveryHost* host) {
       target_idx = non_priority_idx;
       host_free(context.hosts[target_idx]);
       context.hosts[target_idx] = NULL;
+      context.num_hosts--;
     } else {
       // TODO: Indicate to user that host could not be saved
       CHIAKI_LOGE(&(context.log), "Max # of hosts reached; could not save newly discovered host.");

--- a/vita/src/discovery.c
+++ b/vita/src/discovery.c
@@ -1,5 +1,6 @@
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 #include <chiaki/discoveryservice.h>
 #include <chiaki/log.h>
@@ -19,6 +20,8 @@ int save_discovered_host(ChiakiDiscoveryHost* host) {
   // Check if the host is already known, and if not, locate a free spot for it
   uint8_t host_mac[6];
   parse_mac(host->host_id, host_mac);
+
+  bool is_priority = mac_is_priority(host_mac);
 
   // Check if there is an identical discovered host in context; return if so
   for (int host_idx = 0; host_idx < MAX_NUM_HOSTS; host_idx++) {
@@ -41,6 +44,7 @@ int save_discovered_host(ChiakiDiscoveryHost* host) {
 
   // Determine whether there is room in context for a new host to be added
   int target_idx = -1;
+  int non_priority_idx = -1;
   for (int host_idx = 0; host_idx < MAX_NUM_HOSTS; host_idx++) {
     VitaChiakiHost* h = context.hosts[host_idx];
     if (h == NULL) {
@@ -53,13 +57,24 @@ int save_discovered_host(ChiakiDiscoveryHost* host) {
         break;
       }
     }
+    if (!mac_is_priority(h->server_mac)) {
+      non_priority_idx = host_idx;
+    }
   }
 
-  // Maximum number of hosts reached, can't save host
-  // TODO: Indicate to user
+  // Maximum number of hosts reached
   if (target_idx < 0) {
-    CHIAKI_LOGE(&(context.log), "Max # of hosts reached; could not save newly discovered host.");
-    return -1;
+    if (is_priority && (non_priority_idx >= 0)) {
+      // The newly discovered host is a priority one and an existing host is
+      // non-priority, so replace the latter.
+      target_idx = non_priority_idx;
+      host_free(context.hosts[target_idx]);
+      context.hosts[target_idx] = NULL;
+    } else {
+      // TODO: Indicate to user that host could not be saved
+      CHIAKI_LOGE(&(context.log), "Max # of hosts reached; could not save newly discovered host.");
+      return -1;
+    }
   }
 
   // print some info about the host
@@ -99,6 +114,7 @@ int save_discovered_host(ChiakiDiscoveryHost* host) {
 
   ChiakiTarget target = chiaki_discovery_host_system_version_target(host);
   CHIAKI_LOGI(&(context.log),   "Is PS5:                            %s", chiaki_target_is_ps5(target) ? "true" : "false");
+  CHIAKI_LOGI(&(context.log),   "Is priority:                       %s", is_priority ? "true" : "false");
   h->target = target;
   memcpy(&(h->server_mac), &host_mac, 6);
   h->discovery_state =

--- a/vita/src/ui.c
+++ b/vita/src/ui.c
@@ -1096,8 +1096,8 @@ bool draw_messages() {
     i_y ++;
   }
 
-  if (btn_pressed_hold(SCE_CTRL_UP)) {
-    if (overflow) {
+  if (overflow) {
+    if (btn_pressed_hold(SCE_CTRL_UP)) {
       int next_offset = line_offset - 1;
 
       if (next_offset == 1) next_offset = 0;
@@ -1106,16 +1106,20 @@ bool draw_messages() {
       if (next_offset < 0) next_offset = line_offset;
       context.ui_state.mlog_line_offset = next_offset;
     }
-  }
-  if (btn_pressed_hold(SCE_CTRL_DOWN)) {
-    if (overflow) {
-      int next_offset = line_offset + 1;
+    if (btn_pressed_hold(SCE_CTRL_DOWN)) {
+        int next_offset = line_offset + 1;
 
-      if (next_offset == max_line_offset - 1) next_offset = max_line_offset;
-      if (next_offset == 1) next_offset = 2;
+        if (next_offset == max_line_offset - 1) next_offset = max_line_offset;
+        if (next_offset == 1) next_offset = 2;
 
-      if (next_offset > max_line_offset) next_offset = max_line_offset;
-      context.ui_state.mlog_line_offset = next_offset;
+        if (next_offset > max_line_offset) next_offset = max_line_offset;
+        context.ui_state.mlog_line_offset = next_offset;
+    }
+    if (btn_pressed(SCE_CTRL_START)) {
+        context.ui_state.mlog_line_offset = 0;
+    }
+    if (btn_pressed(SCE_CTRL_SELECT)) {
+        context.ui_state.mlog_line_offset = max_line_offset;
     }
   }
 

--- a/vita/src/ui.c
+++ b/vita/src/ui.c
@@ -96,10 +96,42 @@ int SCE_CTRL_CANCEL  = SCE_CTRL_CIRCLE;
 char* confirm_btn_str = "Cross";
 char* cancel_btn_str  = "Circle";
 
+// button hold status
+int last_btn_held = 0;
+uint64_t last_btn_held_start_time = 0;
+uint64_t last_btn_held_time = 0;
+
 /// Check if a button has been newly pressed
 bool btn_pressed(SceCtrlButtons btn) {
   return (context.ui_state.button_state & btn) &&
          !(context.ui_state.old_button_state & btn);
+}
+
+/// Check if a button is being held down (return 25 times per second)
+bool btn_pressed_hold(SceCtrlButtons btn) {
+  if (context.ui_state.button_state & btn) {
+    uint64_t cur_time = sceKernelGetProcessTimeWide();
+    if (!(context.ui_state.old_button_state & btn)) {
+      // Button newly pressed
+      last_btn_held = context.ui_state.button_state;
+      last_btn_held_start_time = cur_time;
+      last_btn_held_time = cur_time;
+      return true;
+    }
+
+    uint64_t delay = 1000000/2;
+    if (cur_time - last_btn_held_start_time > 2 * 1000000) {
+      delay = 0;
+    } else if (cur_time - last_btn_held_start_time > 1000000/2) {
+      delay = 1000000/25;
+    }
+
+    if (cur_time - last_btn_held_time > delay) {
+      last_btn_held_time = cur_time;
+      return true;
+    }
+  }
+  return false;
 }
 
 /// Load all textures required for rendering the UI
@@ -1064,7 +1096,7 @@ bool draw_messages() {
     i_y ++;
   }
 
-  if (btn_pressed(SCE_CTRL_UP)) {
+  if (btn_pressed_hold(SCE_CTRL_UP)) {
     if (overflow) {
       int next_offset = line_offset - 1;
 
@@ -1075,7 +1107,7 @@ bool draw_messages() {
       context.ui_state.mlog_line_offset = next_offset;
     }
   }
-  if (btn_pressed(SCE_CTRL_DOWN)) {
+  if (btn_pressed_hold(SCE_CTRL_DOWN)) {
     if (overflow) {
       int next_offset = line_offset + 1;
 

--- a/vita/src/util.c
+++ b/vita/src/util.c
@@ -1,22 +1,50 @@
 #include <stdio.h>
+#include <string.h>
+#include <chiaki/common.h>
 #include <chiaki/base64.h>
 #include <psp2/message_dialog.h>
 #include "util.h"
+#include "context.h"
 
-void parse_b64(const char* val, uint8_t* dest, size_t len) {
-  chiaki_base64_decode(val, get_base64_size(len), dest, &len);
+int parse_b64(const char* val, uint8_t* dest, size_t len) {
+  ChiakiErrorCode err = chiaki_base64_decode(val, get_base64_size(len), dest, &len);
+  if (err == CHIAKI_ERR_SUCCESS) return 0;
+  return 1;
 }
 
-void parse_mac(const char* mac_str, uint8_t* mac_dest) {
+int parse_mac_hex_or_b64(const char* mac_str, uint8_t* mac_dest) {
+  // Attempt to parse a hex or b64 mac address
+  size_t len = strnlen(mac_str, 20);
+  if (len < 12) {
+    // attempt to parse as b64
+    return parse_b64(mac_str, mac_dest, 6);
+  } else {
+    // attempt to parse as mac
+    return parse_mac(mac_str, mac_dest);
+  }
+}
+
+int parse_mac(const char* mac_str, uint8_t* mac_dest) {
   // Given a string of length 12, e.g. DEADBEEF0000, convert to 6 ints
+  // Allow : to be interspersed. E.g., DE:AD:BE:EF:00:00.
+
+  size_t len = strnlen(mac_str, 20);
+  if (len < 12) return 1;
+
+  int c_offset = 0;
   for (int j = 0; j < 6; j++) {
     char digit[3];
-    digit[0] = mac_str[2*j];
-    digit[1] = mac_str[2*j+1];
-    digit[2] = 0;
+
+    // move forward by one if there is a colon
+    if (mac_str[2*j + c_offset] == ':') c_offset++;
+
+    digit[0] = mac_str[2*j + c_offset];
+    digit[1] = mac_str[2*j+1 + c_offset];
+    digit[2] = 0; // null termination
 
     mac_dest[j] = strtol(digit, NULL, 16);
   }
+  return 0;
 }
 
 // void parse_b64(const char* val, uint8_t* dest, size_t len) {

--- a/vita/src/util.c
+++ b/vita/src/util.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 #include <chiaki/common.h>
 #include <chiaki/base64.h>
@@ -45,6 +46,20 @@ int parse_mac(const char* mac_str, uint8_t* mac_dest) {
     mac_dest[j] = strtol(digit, NULL, 16);
   }
   return 0;
+}
+
+bool mac_is_priority(uint8_t* host_mac) {
+  for (int p_i = 0; p_i < context.config.num_priority_host_macs; p_i++) {
+    bool _match = true;
+    for (int j = 0; j < 6; j++) {
+      if (host_mac[j] != context.config.priority_host_macs[p_i][j]) {
+        _match = false;
+        break;
+      }
+    }
+    if (_match) return true;
+  }
+  return false;
 }
 
 // void parse_b64(const char* val, uint8_t* dest, size_t len) {


### PR DESCRIPTION
Enable a new section in the config file as follows:

### Priority hosts
The Vitaki UI is limited to 4 consoles. If you are on a crowded network with many consoles and yours isn't showing up, you can manually add the following to the config file:
```toml
[[priority_hosts]]
server_mac = "00:11:11:11:11:11"

[[priority_hosts]]
server_mac = "00:22:22:22:22:22"
```
and so on for each console you want to prioritize, where the MAC address is the LAN MAC address of your PS5/PS4 console (you can find it in `Settings > Network > Connection Status > View Connection Status`).

Note that each additional priority host should have its own `[[priority_hosts]]` header above it. Also, be sure to quote the MAC address. If Vitaki crashes immediately on opening, it is probably due to an invalid TOML file breaking the parser.
