### PR TITLE
PSTV support + retaining AnalogsEnhancer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Note: if the remote host cannot be reached, it will get stuck on "Trying to requ
 Some configuration lacks a UI but can be set in the config file located at `ux0:data/vita-chiaki/chiaki.toml`.
 - `circle_btn_confirm = true` swaps circle and cross in the main UI, so that circle is confirm and cross is cancel (`false` makes cross into confirm and circle into cancel). Note that this does not affect the button mappings in remote play, only in the UI before remote play starts.
 - `auto_discovery = false` makes Vitaki not start discovery on launch. It can still be started manually by selecting the wifi icon.
+- `enable_analogsenhancer = true` makes Vitaki-fork compatible with the [AnalogsEnhancer plugin](https://github.com/Rinnegatamante/AnalogsEnhancer/). This option is `false` by default, since compatibility with PSTV controllers is then broken.
 
 ## Known issues & troubleshooting
 - Latency. On remote connections (not local WLAN), it's especially bad. ([Relevant GitHub issue](https://github.com/ywnico/vitaki-fork/issues/12))

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This fork builds on AAGaming's work with the following updates:
 2. Implemented controls
     - Control mappings for L2, R2, L3, R3, and touchpad (trapezoid button), following the official ps4 remote play maps in `vs0:app/NPXS10013/keymap/`. Note that `Select` + `Start` sends the PS (home) button.
     - Motion controls (thanks to [@Epicpkmn11](https://github.com/Epicpkmn11), who also contributed some other controller improvements)
+    - Enable use of external controllers on PSTV (thanks to [@TheThomasD](https://github.com/TheThomasD))
 3. Implemented external network remote play (with manually-specified remote IP addresses)
 4. Fixed console wakeup
 5. Made debug logs visible, added tooltips on some buttons

--- a/scripts/Dockerfile.vita.jammy
+++ b/scripts/Dockerfile.vita.jammy
@@ -1,0 +1,45 @@
+FROM ubuntu:jammy
+
+# Install basic dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    git \
+    cmake \
+    ninja-build \
+    pkg-config \
+    build-essential \
+    curl \
+    wget \
+    python3 \
+    python3-pip \
+    python3-protobuf \
+    libssl-dev \
+    libopus-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libjson-c-dev \
+    libminiupnpc-dev \
+    libspeexdsp-dev \
+    zlib1g-dev \
+    ca-certificates \
+    sudo \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Vita SDK
+ENV VITASDK=/usr/local/vitasdk
+ENV PATH=$VITASDK/bin:$PATH
+
+RUN git clone https://github.com/vitasdk/vdpm && \
+    cd vdpm && \
+    ./bootstrap-vitasdk.sh && \
+    ./install-all.sh && \
+    cd .. && \
+    rm -rf vdpm
+
+# Set up environment
+WORKDIR /build
+
+# Default command
+CMD ["/bin/bash"]

--- a/scripts/docker-build-vita.sh
+++ b/scripts/docker-build-vita.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+SCRIPTDIR=$(dirname "$0")
+PROJECTDIR=$(realpath "${SCRIPTDIR}/../")
+
+# Initialize submodules if not already done
+echo "Initializing submodules..."
+if git submodule status | grep -q "^-"; then
+    git submodule update --init --recursive
+else
+    echo "Submodules already initialized."
+fi
+
+# Build Docker image
+echo "Building Vita SDK Docker image..."
+docker build -f "${SCRIPTDIR}/Dockerfile.vita.jammy" -t vitaki-vita-builder "${SCRIPTDIR}"
+
+# Run build in container
+echo "Building Vitaki for PS Vita..."
+docker run --rm \
+    -v "${PROJECTDIR}:/build" \
+    -w /build \
+    vitaki-vita-builder \
+    bash -c "cd /build && ./scripts/vita/build.sh"
+
+echo "Build completed! VPK file should be in build/vita/"

--- a/scripts/vita/build.sh
+++ b/scripts/vita/build.sh
@@ -25,8 +25,8 @@ build_chiaki (){
 			-DCHIAKI_LIB_ENABLE_OPUS=ON
 	# fi
 	make -j$(nproc) -C "./build"
-	python3 ./scripts/vita/devtool.py --host $PSVITAIP upload
-	python3 ./scripts/vita/devtool.py --host $PSVITAIP launch
+	#python3 ./scripts/vita/devtool.py --host $PSVITAIP upload
+	#python3 ./scripts/vita/devtool.py --host $PSVITAIP launch
 	popd
 }
 

--- a/vita/include/config.h
+++ b/vita/include/config.h
@@ -33,6 +33,7 @@ typedef struct vita_chiaki_config_t {
   // controller map id // TODO should probably replace with fully customizable map
   int controller_map_id;
   bool circle_btn_confirm;
+  bool enable_analogsenhancer;
 } VitaChiakiConfig;
 
 void config_parse(VitaChiakiConfig* cfg);

--- a/vita/include/controller.h
+++ b/vita/include/controller.h
@@ -25,6 +25,7 @@ typedef enum vitaki_controller_map_id_t {
   VITAKI_CONTROLLER_MAP_107    =  107, // L3, R3 front touchscreen upper corners; no L2 R2; touchpad front middle
   VITAKI_CONTROLLER_MAP_125    = 125, // L3, R3 front touchscreen upper corners; L2, R2 front touchscreen lower corners; no touchpad
   VITAKI_CONTROLLER_MAP_199    = 199, // map ywnico randomly came up with (swap L2R2 <> L3R3)
+  VITAKI_CONTROLLER_MAP_200    = 200, // PSTV + PS4: disable front touchpad and touch-region mappings
 } VitakiControllerMapId;
 
 // Control buttons (used for array indices => start at 0)

--- a/vita/src/config.c
+++ b/vita/src/config.c
@@ -81,6 +81,8 @@ void config_parse(VitaChiakiConfig* cfg) {
 
   bool circle_btn_confirm_default = get_circle_btn_confirm_default();
   cfg->circle_btn_confirm = circle_btn_confirm_default;
+  bool enable_analogsenhancer_default = false;
+  cfg->enable_analogsenhancer = enable_analogsenhancer_default;
 
   if (access(CFG_FILENAME, F_OK) == 0) {
     FILE* fp = fopen(CFG_FILENAME, "r");
@@ -141,6 +143,9 @@ void config_parse(VitaChiakiConfig* cfg) {
 
       datum = toml_bool_in(settings, "circle_btn_confirm");
       cfg->circle_btn_confirm = datum.ok ? datum.u.b : circle_btn_confirm_default;
+
+      datum = toml_bool_in(settings, "enable_analogsenhancer");
+      cfg->enable_analogsenhancer = datum.ok ? datum.u.b : enable_analogsenhancer_default;
     }
 
     toml_array_t* regist_hosts = toml_array_in(parsed, "registered_hosts");

--- a/vita/src/controller.c
+++ b/vita/src/controller.c
@@ -149,6 +149,9 @@ void init_controller_map(VitakiCtrlMapInfo* vcmi, VitakiControllerMapId controll
 
     vcmi->in_out_btn[VITAKI_CTRL_IN_REARTOUCH_UL] = VITAKI_CTRL_OUT_L3;
     vcmi->in_out_btn[VITAKI_CTRL_IN_REARTOUCH_UR] = VITAKI_CTRL_OUT_R3;
+  } else if (controller_map_id == VITAKI_CONTROLLER_MAP_200) {
+    // PSTV + PS4: disable all front touch mappings to avoid interference
+    // L2/R2 are handled by physical triggers, L3/R3 by buttons
   } else { // default, VITAKI_CONTROLLER_MAP_0
     vcmi->in_out_btn[VITAKI_CTRL_IN_L1]                  = VITAKI_CTRL_OUT_L1;
     vcmi->in_out_btn[VITAKI_CTRL_IN_R1]                  = VITAKI_CTRL_OUT_R1;

--- a/vita/src/host.c
+++ b/vita/src/host.c
@@ -176,9 +176,12 @@ static void *input_thread_func(void* user) {
   if (!vcmi.did_init) init_controller_map(&vcmi, context.config.controller_map_id);
 
   // Touchscreen setup
-	sceTouchSetSamplingState(SCE_TOUCH_PORT_FRONT, SCE_TOUCH_SAMPLING_STATE_START);
+  bool enable_front_touch = (vcmi.in_out_btn[VITAKI_CTRL_IN_FRONTTOUCH_ANY] != VITAKI_CTRL_OUT_NONE);
+  if (enable_front_touch) {
+    sceTouchSetSamplingState(SCE_TOUCH_PORT_FRONT, SCE_TOUCH_SAMPLING_STATE_START);
+    sceTouchEnableTouchForce(SCE_TOUCH_PORT_FRONT);
+  }
 	sceTouchSetSamplingState(SCE_TOUCH_PORT_BACK, SCE_TOUCH_SAMPLING_STATE_START);
-	sceTouchEnableTouchForce(SCE_TOUCH_PORT_FRONT);
 	sceTouchEnableTouchForce(SCE_TOUCH_PORT_BACK);
 	SceTouchData touch[SCE_TOUCH_PORT_MAX_NUM];
   int TOUCH_MAX_WIDTH = 1919;

--- a/vita/src/host.c
+++ b/vita/src/host.c
@@ -200,15 +200,15 @@ static void *input_thread_func(void* user) {
 
   while (true) {
 
-    // TODO enable using triggers as L2, R2
     // TODO enable home button, with long hold sent back to Vita?
+    // Note: L2/R2 and PS button from external controllers (PSTV) are now supported
 
 
     if (stream->is_streaming) {
       int start_time_us = sceKernelGetProcessTimeWide();
 
-      // get button state
-      sceCtrlPeekBufferPositive(0, &ctrl, 1);
+      // get button state - use Ext2 to support L2/R2/PS button from external controllers on PSTV
+      sceCtrlPeekBufferPositiveExt2(0, &ctrl, 1);
 
       // get touchscreen state
       for(int port = 0; port < SCE_TOUCH_PORT_MAX_NUM; port++) {
@@ -309,23 +309,49 @@ static void *input_thread_func(void* user) {
       if (ctrl.buttons & SCE_CTRL_CIRCLE)   stream->controller_state.buttons |= CHIAKI_CONTROLLER_BUTTON_MOON;
       if (ctrl.buttons & SCE_CTRL_CROSS)    stream->controller_state.buttons |= CHIAKI_CONTROLLER_BUTTON_CROSS;
       if (ctrl.buttons & SCE_CTRL_SQUARE)   stream->controller_state.buttons |= CHIAKI_CONTROLLER_BUTTON_BOX;
-      // what is L3??
+      
+      // L3/R3 buttons (work on both Vita with external controller and PSTV)
       if (ctrl.buttons & SCE_CTRL_L3)       stream->controller_state.buttons |= CHIAKI_CONTROLLER_BUTTON_L3;
       if (ctrl.buttons & SCE_CTRL_R3)       stream->controller_state.buttons |= CHIAKI_CONTROLLER_BUTTON_R3;
 
-      if (ctrl.buttons & SCE_CTRL_LTRIGGER) {
+      // L1/R1 handling - support both Vita and PSTV external controllers
+      // Support both SCE_CTRL_L1/R1 and SCE_CTRL_LTRIGGER/RTRIGGER for compatibility
+      if ((ctrl.buttons & SCE_CTRL_L1) || (ctrl.buttons & SCE_CTRL_LTRIGGER)) {
         if (reartouch_left && vitaki_reartouch_left_l1_mapped) {
           set_ctrl_l2pos(stream, VITAKI_CTRL_IN_REARTOUCH_LEFT_L1);
         } else {
           set_ctrl_l2pos(stream, VITAKI_CTRL_IN_L1);
         }
       }
-      if (ctrl.buttons & SCE_CTRL_RTRIGGER) {
+      if ((ctrl.buttons & SCE_CTRL_R1) || (ctrl.buttons & SCE_CTRL_RTRIGGER)) {
         if (reartouch_right && vitaki_reartouch_right_r1_mapped) {
           set_ctrl_r2pos(stream, VITAKI_CTRL_IN_REARTOUCH_RIGHT_R1);
         } else {
           set_ctrl_r2pos(stream, VITAKI_CTRL_IN_R1);
         }
+      }
+
+      // Handle L2/R2 from external controllers (PSTV with PS3/PS4 controllers)
+      // These buttons don't exist on the Vita itself, only on external controllers
+      // Check both digital buttons and analog trigger values
+      if (ctrl.buttons & SCE_CTRL_L2) {
+        stream->controller_state.l2_state = 0xff;
+      }
+      if (ctrl.buttons & SCE_CTRL_R2) {
+        stream->controller_state.r2_state = 0xff;
+      }
+      // Also check analog trigger values (lt/rt fields in SceCtrlData when using Ext2)
+      // On PSTV with PS3/PS4 controllers, triggers report as analog values
+      if (ctrl.lt > 0) {
+        stream->controller_state.l2_state = ctrl.lt;
+      }
+      if (ctrl.rt > 0) {
+        stream->controller_state.r2_state = ctrl.rt;
+      }
+
+      // Handle PS button from external controllers (PSTV)
+      if (ctrl.buttons & SCE_CTRL_PSBUTTON) {
+        stream->controller_state.buttons |= CHIAKI_CONTROLLER_BUTTON_PS;
       }
 
       // Select + Start

--- a/vita/src/host.c
+++ b/vita/src/host.c
@@ -210,8 +210,14 @@ static void *input_thread_func(void* user) {
     if (stream->is_streaming) {
       int start_time_us = sceKernelGetProcessTimeWide();
 
-      // get button state - use Ext2 to support L2/R2/PS button from external controllers on PSTV
-      sceCtrlPeekBufferPositiveExt2(0, &ctrl, 1);
+      // get button state
+      // use Ext2 to support L2/R2/PS button from external controllers on PSTV
+      // unless the user has specifically turned on the enable_analogsenhancer flag
+      if (context.config.enable_analogsenhancer) {
+        sceCtrlPeekBufferPositive(0, &ctrl, 1);
+      } else {
+        sceCtrlPeekBufferPositiveExt2(0, &ctrl, 1);
+      }
 
       // get touchscreen state
       for(int port = 0; port < SCE_TOUCH_PORT_MAX_NUM; port++) {

--- a/vita/src/ui.c
+++ b/vita/src/ui.c
@@ -714,10 +714,13 @@ bool draw_settings() {
   vita2d_font_draw_text(font, info_x, info_y + 10*info_y_delta, COLOR_WHITE, font_size,
                         "99: L2, R2 = L1 + rear, R1 + rear; L3 = Left+Square, R3 = Right+Circle; touchpad entire front"
                         );
-  vita2d_font_draw_text(font, info_x, info_y + 11*info_y_delta + info_y_delta/2, COLOR_WHITE, font_size,
+  vita2d_font_draw_text(font, info_x, info_y + 11*info_y_delta, COLOR_WHITE, font_size,
+                        "200: PSTV: disable touchpad (recommended for PS4 on PSTV)"
+                        );
+  vita2d_font_draw_text(font, info_x, info_y + 12*info_y_delta + info_y_delta/3, COLOR_WHITE, font_size,
                         "Add 100 to swap L2<->L3 and R2<->R3"
                         );
-  vita2d_font_draw_text(font, info_x, info_y + 13*info_y_delta, COLOR_WHITE, font_size,
+  vita2d_font_draw_text(font, info_x, info_y + 13*info_y_delta + info_y_delta/3, COLOR_WHITE, font_size,
                         "In all maps, press Start + Select simultaneously for PS (home) button"
                         );
 


### PR DESCRIPTION
Based on PR #41:
> This should be a fix for https://github.com/ywnico/vitaki-fork/issues/18.
> I tested it on my PSTV and it works fine with a PS3 controller. Haven't tried it on my PS Vita, yet.
> I also added a build script that uses a docker-based build approach for convenience as I had some trouble building the VPK at first. I expect this to make the build easier for others as well (if they have docker, that is).

Adds `enable_analogsenhancer` option so that people reliant on the plugin for their analog deadzones can keep using it, despite the PSTV updates.